### PR TITLE
Add support for CBOR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ autoexamples = true
 all-features = true
 
 [features]
-default = ["serde", "bootstrap", "bootstrap-simple"]
-serde = ["serde_", "bincode"]
+default = ["serde", "bincode", "bootstrap", "bootstrap-simple"]
+serde = ["serde_"]
 bootstrap = ["serde"]
+cbor = ["serde_cbor"]
 bootstrap-simple = ["bootstrap", "rand"]
 
 [dependencies]
@@ -25,6 +26,7 @@ libc = "0.2.67"
 nix = "0.17.0"
 serde_ = { package = "serde", version = "1.0.104", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
+serde_cbor = { version = "0.11.1", optional = true }
 rand = { version = "0.7.3", optional = true }
 
 [[example]]

--- a/examples/proc.rs
+++ b/examples/proc.rs
@@ -1,7 +1,9 @@
 use serde_::{Deserialize, Serialize};
 use std::env;
 use std::process;
-use unix_ipc::{channel, Bootstrapper, Receiver, Sender};
+use unix_ipc::{
+    channel, Bincode, BincodeReceiver as Receiver, BincodeSender as Sender, Bootstrapper,
+};
 
 const ENV_VAR: &str = "PROC_CONNECT_TO";
 
@@ -25,7 +27,7 @@ fn main() {
             }
         }
     } else {
-        let bootstrapper = Bootstrapper::new().unwrap();
+        let bootstrapper: Bootstrapper<Bincode, _> = Bootstrapper::new().unwrap();
         let mut child = process::Command::new(env::current_exe().unwrap())
             .env(ENV_VAR, bootstrapper.path())
             .spawn()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,5 +1,7 @@
 use serde_::{Deserialize, Serialize};
-use unix_ipc::{channel, Bootstrapper, Receiver, Sender};
+use unix_ipc::{
+    channel, Bincode, BincodeReceiver as Receiver, BincodeSender as Sender, Bootstrapper,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(crate = "serde_")]
@@ -9,7 +11,7 @@ pub enum Task {
 }
 
 fn main() {
-    let bootstrapper = Bootstrapper::new().unwrap();
+    let bootstrapper: Bootstrapper<Bincode, _> = Bootstrapper::new().unwrap();
     let path = bootstrapper.path().to_owned();
 
     std::thread::spawn(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! # use ::serde_ as serde;
 //! use std::env;
 //! use std::process;
-//! use unix_ipc::{channel, Bootstrapper, Receiver, Sender};
+//! use unix_ipc::{channel, Bootstrapper, BincodeReceiver as Receiver, BincodeSender as Sender, Bincode};
 //! use serde::{Deserialize, Serialize};
 //!
 //! const ENV_VAR: &str = "PROC_CONNECT_TO";
@@ -46,7 +46,7 @@
 //!         }
 //!     }
 //! } else {
-//!     let bootstrapper = Bootstrapper::new().unwrap();
+//!     let bootstrapper: Bootstrapper<Bincode, _> = Bootstrapper::new().unwrap();
 //!     let mut child = process::Command::new(env::current_exe().unwrap())
 //!         .env(ENV_VAR, bootstrapper.path())
 //!         .spawn()


### PR DESCRIPTION
This PR adds optional support for using [CBOR](https://cbor.io/) instead of bincode as the "wire" format. It introduces a `Format` trait and impls of it for bincode and CBOR.