### PR TITLE
Fix fd leaked when sending serialized channel

### DIFF
--- a/src/raw_channel.rs
+++ b/src/raw_channel.rs
@@ -88,9 +88,7 @@ macro_rules! fd_impl {
 
         impl Drop for $ty {
             fn drop(&mut self) {
-                if !self.dead.load(Ordering::SeqCst) {
-                    unistd::close(self.fd).ok();
-                }
+                unistd::close(self.fd).ok();
             }
         }
     };


### PR DESCRIPTION
Previously, the dead flag was used to prevent a RawChannel's underlying fd to be closed if it had been serialized. This prevented the fd from being closed in between the channel being serialized and its fd being sent through another RawChannel.

However, while this did prevent the fd from becoming invalidated, it also meant that the fd is never closed, causing an fd leak.

A better solution in this case is to ensure the fd survives until it is sent by making sure the RawChannel is not dropped until after the send function is called. This is achieved by simply passing a reference to the serialize function instead of consuming the RawChannel. The underlying fd can then be closed unconditionally when the RawChannel is dropped.

Fixes #3 